### PR TITLE
fix: Don't fetch staff without ministry

### DIFF
--- a/pages/connect/[page].js
+++ b/pages/connect/[page].js
@@ -209,18 +209,21 @@ export async function getServerSideProps(context) {
     skip: !context.params.page,
   });
 
-  const staffResponse = await apolloClient.query({
-    query: GET_STAFF,
-    variables: {
-      ministry: pageResponse?.data?.node?.ministry,
-    },
-  });
+  let staffResponse;
+  if (pageResponse?.data?.node?.ministry) {
+    staffResponse = await apolloClient.query({
+      query: GET_STAFF,
+      variables: {
+        ministry: pageResponse?.data?.node?.ministry,
+      },
+    });
+  }
 
   return {
     props: {
       initialApolloState: apolloClient.cache.extract(),
       data: pageResponse?.data,
-      staff: staffResponse?.data,
+      staff: staffResponse ? staffResponse.data : [],
     },
   };
 }


### PR DESCRIPTION
This brings us to the point where we can actually see all of the Connect pages without timeouts