### PR TITLE
UseStaticProps on homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -16,7 +16,7 @@ export default function Home(props = {}) {
   );
 }
 
-export async function getServerSideProps() {
+export async function getStaticProps() {
   const apolloClient = initializeApollo();
 
   const sermonsRequest = await apolloClient.query({
@@ -54,5 +54,9 @@ export async function getServerSideProps() {
       articles: articles?.data?.node?.childContentItemsConnection?.edges,
       sermon: sermonRequest?.data?.node,
     },
+    // Next.js will attempt to re-generate the page:
+    // - When a request comes in
+    // - At most once every second
+    revalidate: 60, // In seconds
   };
 }


### PR DESCRIPTION
This is inline with what @conrad-vanl was talking about - `Next.js` will now send the same static, cached HTML to all users for the base HTML for the home page. It will be revalidated at most once every 60 seconds, so changes in Rock will still apply (after a small delay) 