### PR TITLE
fix: Search overlay bug

### DIFF
--- a/components/LargeImage/LargeImage.styles.js
+++ b/components/LargeImage/LargeImage.styles.js
@@ -30,19 +30,23 @@ export const TextContainer = styled(Box)`
   border-radius: 0 0 24px 24px;
   background: rgba(0, 0, 0, 0.5);
   flex: 1;
-
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  left: 0;
 
   @media screen and (max-width: ${themeGet('breakpoints.md')}) {
-    ${props => !props.staticHeight ? `backdrop-filter: blur(24px);` : '' }
+    ${props => (!props.staticHeight ? `backdrop-filter: blur(24px);` : '')}
   }
 
-  @media screen and (min-width: ${props => props.staticHeight ? 0 : themeGet('breakpoints.md')}) {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
+  @media screen and (min-width: ${props =>
+      props.staticHeight ? 0 : themeGet('breakpoints.md')}) {
     width: 100%;
-    background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 0.95) 100%);
+    background: linear-gradient(
+      180deg,
+      rgba(0, 0, 0, 0) 0%,
+      rgba(0, 0, 0, 0.95) 100%
+    );
   }
   ${system}
 `;
@@ -55,17 +59,19 @@ export default styled(Box)`
   cursor: ${props => (props.onClick ? 'pointer' : 'default')};
 
   ${props =>
-    props.backgroundSrc ? `background: url("${props.backgroundSrc}") no-repeat bottom center;` : ''
-  }
+    props.backgroundSrc
+      ? `background: url("${props.backgroundSrc}") no-repeat bottom center;`
+      : ''}
 
   background-size: contain;
 
   ${props =>
-    props.height ? `
+    props.height
+      ? `
       display: flex;
       flex-direction: column;
-    ` : ''
-  }
+    `
+      : ''}
 
   ${system}
 `;


### PR DESCRIPTION
### About
Fixes a bug where LargeImages in the Search feed were not displaying correctly on small screen sizes.

### Screenshots
Before:
<img src="https://user-images.githubusercontent.com/72768221/132387342-2547ecca-a575-44cd-a15b-eb31213411d1.png" width="50%" >

After:
<img width="50%" alt="Screen Shot 2021-09-07 at 12 28 42 PM" src="https://user-images.githubusercontent.com/72768221/132387438-3fdb83c9-f92d-4d72-930e-ede55d7dbb1b.png">

Other:
These show that it doesn't negatively affect other images at different sizes.
<img width="50%" alt="Screen Shot 2021-09-07 at 12 29 57 PM" src="https://user-images.githubusercontent.com/72768221/132387570-a05522ca-e6dd-41d6-aa26-2ca795a958c6.png">
<img width="50%" alt="Screen Shot 2021-09-07 at 12 29 26 PM" src="https://user-images.githubusercontent.com/72768221/132387579-782534e2-c268-4282-81f6-073d523fcde2.png">
<img width="50%" alt="Screen Shot 2021-09-07 at 12 29 42 PM" src="https://user-images.githubusercontent.com/72768221/132387581-5ef29405-53a3-473b-8cc5-5b4b0fbfbe97.png">