### PR TITLE
fix: set the size of largeArticle on Home tab responsively

### DIFF
--- a/components/HomeFeed/HomeFeed.js
+++ b/components/HomeFeed/HomeFeed.js
@@ -167,6 +167,7 @@ function HomeFeedLargeArticle({ article }) {
     <Box position="relative" height="100%" width="100%">
       <LargeImage
         height="100%"
+        size={{ _: 'm', md: 'l' }}
         dropShadow
         text={article?.title}
         color="white"


### PR DESCRIPTION
Large Article on the Home page was set to always large, so that has been changed to be medium on small screen sizes. This was causing the text container to be very large and coverup the cover image.

<img width="414" alt="Screen Shot 2021-09-15 at 4 27 32 PM" src="https://user-images.githubusercontent.com/72768221/133512639-9dce792d-a01f-4400-a45c-e9ac37405089.png">
