### PR TITLE
fix: Item overlay

### DIFF
--- a/components/LargeImage/LargeImage.styles.js
+++ b/components/LargeImage/LargeImage.styles.js
@@ -30,17 +30,17 @@ export const TextContainer = styled(Box)`
   border-radius: 0 0 24px 24px;
   background: rgba(0, 0, 0, 0.5);
   flex: 1;
-  position: absolute;
-  bottom: 0;
-  right: 0;
-  left: 0;
 
-  @media screen and (max-width: ${themeGet('breakpoints.md')}) {
+  @media screen and (max-width: ${themeGet('breakpoints.sm')}) {
     ${props => (!props.staticHeight ? `backdrop-filter: blur(24px);` : '')}
   }
 
   @media screen and (min-width: ${props =>
-      props.staticHeight ? 0 : themeGet('breakpoints.md')}) {
+      props.staticHeight ? 0 : themeGet('breakpoints.sm')}) {
+    position: absolute;
+    bottom: 0;
+    right: 0;
+    left: 0;
     width: 100%;
     background: linear-gradient(
       180deg,

--- a/components/Search/Hit.js
+++ b/components/Search/Hit.js
@@ -10,10 +10,14 @@ function Hit(props) {
     <LargeImage
       action={url ? () => router.push(url) : null}
       src={props.hit.coverImage ? props.hit.coverImage.sources[0].uri : null}
-      text={props.hit.title}
+      text={
+        props.hit.title.length > 35
+          ? props.hit.title.substring(0, 35) + '...'
+          : props.hit.title
+      }
       color="white"
       width={{ sm: '300px' }}
-      height={{ sm: "225px" }}
+      height={{ sm: '225px' }}
       m="xs"
       size="m"
     />

--- a/components/Search/Hit.js
+++ b/components/Search/Hit.js
@@ -13,7 +13,7 @@ function Hit(props) {
       text={props.hit.title}
       color="white"
       width={{ sm: '300px' }}
-      height="225px"
+      height={{ sm: "225px" }}
       m="xs"
       size="m"
     />


### PR DESCRIPTION
This PR reverts a previous fix to the Search page that had adverse affects on the Home page. It also addresses titles being too long to nicely fit on a card on the Search hits, and truncates those titles.

Home Page
<img width="1609" alt="Screen Shot 2021-09-30 at 5 25 34 PM" src="https://user-images.githubusercontent.com/72768221/135538245-d61e791b-3fd6-4ca1-a7e9-3109e783a054.png">
<img width="422" alt="Screen Shot 2021-09-30 at 5 28 55 PM" src="https://user-images.githubusercontent.com/72768221/135538515-3cc7ffea-112f-44ba-8919-39d3f44fa45e.png">

Search Page
<img width="1388" alt="Screen Shot 2021-09-30 at 5 26 17 PM" src="https://user-images.githubusercontent.com/72768221/135538264-c7ac81ca-4291-46a1-9c9d-b32087d09934.png">
https://user-images.githubusercontent.com/72768221/135538672-a8712653-abda-41c4-863b-360566122f1d.mov


