### PR TITLE
fix: increased filtered search results to 12

### DIFF
--- a/components/Search/RefinementsList.js
+++ b/components/Search/RefinementsList.js
@@ -44,7 +44,7 @@ export default function RefinementsList({
             </Panel>
           </Box>
         ))}
-        <Configure hitsPerPage={8} />
+        <Configure hitsPerPage={12} />
       </Styled.Refinements>
     </Styled.RefinementsBackground>
   );


### PR DESCRIPTION
When filtering search results, show 12 now instead of 8.

<img width="1726" alt="Screen Shot 2021-10-05 at 9 41 10 AM" src="https://user-images.githubusercontent.com/72768221/136045549-7714141a-5de9-4151-9e57-1100b2766806.png">
