### PR TITLE
fix: allow overflow on refinement list

### DIFF
--- a/ui-kit/GlobalStyles/AlgoliaStyles.styles.js
+++ b/ui-kit/GlobalStyles/AlgoliaStyles.styles.js
@@ -97,7 +97,7 @@ export default css`
 
   .ais-RefinementList-labelText {
     margin-left: ${themeGet('space.xs')};
-    overflow: hidden;
+    overflow: visible;
     text-overflow: ellipsis;
     white-space: nowrap;
   }


### PR DESCRIPTION
Some text characters were being cut off in the refinement list. This is a targeted fix and should not have any other side effects on the site. Characters that go below the base line of text were being cut off. See pictures below.

# Before
<img width="260" alt="Screen Shot 2021-10-05 at 9 17 59 AM" src="https://user-images.githubusercontent.com/72768221/136049850-f744c3e9-d96f-437b-92ae-7ede02a4b81f.png">

# After 
<img width="281" alt="Screen Shot 2021-10-05 at 10 01 56 AM" src="https://user-images.githubusercontent.com/72768221/136049858-7f3b63b1-b5a1-4e74-b3ec-66d25ffeac79.png">

