### PR TITLE
[Support] Request 1a - Add back blur to other, non-series related, images

### DIFF
--- a/components/MainPhotoHeader/MainPhotoHeader.js
+++ b/components/MainPhotoHeader/MainPhotoHeader.js
@@ -18,6 +18,7 @@ function MainPhotoHeader({
   overlay,
   content,
   justifyText,
+  bgBlurred,
   imageProps = {},
   ...props
 } = {}) {
@@ -25,7 +26,7 @@ function MainPhotoHeader({
   return (
     <Styled.Container {...props}>
       {backdrop && <Styled.Backdrop src={_backgroundSrc} />}
-      {backdrop && <Styled.BackdropOverlay bg="bg_alt" opacity="0.4" />}
+      {backdrop && <Styled.BackdropOverlay bg="bg_alt" blurred={bgBlurred} />}
       <Styled.ImageContainer backdrop={backdrop}>
         {showImage && (
           <Styled.Image

--- a/components/MainPhotoHeader/MainPhotoHeader.styles.js
+++ b/components/MainPhotoHeader/MainPhotoHeader.styles.js
@@ -87,6 +87,7 @@ Styled.Image = styled(Image)`
 
 Styled.BackdropOverlay = styled(Box)`
   display: none;
+  opacity: 0.4;
 
   @media screen and (min-width: ${themeGet('breakpoints.xl')}) {
     display: block;
@@ -95,8 +96,10 @@ Styled.BackdropOverlay = styled(Box)`
     position: absolute;
     top: 0;
     width: 100%;
-    opacity: 1;
     background-color: rgba(255, 255, 255, 0.33);
+
+    ${({ blurred = true }) => (blurred ? 'opacity: 1;' : 'opacity: 0;')}
+    ${({ blurred = true }) => (blurred ? 'backdrop-filter: blur(25px);' : '')}
   }
 `;
 

--- a/components/SinglePages/ContentSeriesContentItem.js
+++ b/components/SinglePages/ContentSeriesContentItem.js
@@ -1,11 +1,11 @@
+import { useLazyQuery } from '@apollo/client';
 import { LargeImage, Layout, MainPhotoHeader } from 'components';
 import { GET_MESSAGE_CHANNEL } from 'hooks/useMessageChannel';
-import { Box, Button, Section } from 'ui-kit';
 import { useRouter } from 'next/router';
-import { getIdSuffix, getMetaData, getSlugFromURL } from 'utils';
-import { useTheme } from 'styled-components';
 import { useState } from 'react';
-import { useLazyQuery } from '@apollo/client';
+import { useTheme } from 'styled-components';
+import { Box, Button, Section } from 'ui-kit';
+import { getMetaData, getSlugFromURL } from 'utils';
 
 export default function ContentSeriesContentItem({ item, dropdownData } = {}) {
   const router = useRouter();

--- a/components/SinglePages/MediaContentItem.js
+++ b/components/SinglePages/MediaContentItem.js
@@ -39,6 +39,7 @@ export default function WeekendContentItem({ item, dropdownData } = {}) {
           src={mainPhoto}
           showImage={false}
           overlay=""
+          bgBlurred={false}
           content={
             !!(
               (clips?.length &&

--- a/pages/watch/[series]/index.js
+++ b/pages/watch/[series]/index.js
@@ -33,37 +33,37 @@ export default function Series({ item, dropdownData } = {}) {
 
   return (
     <Layout meta={getMetaData(item)} dropdownData={dropdownData}>
-        <Heading
-          mt="l"
-          textAlign="center"
-          fontWeight="800"
-          fontSize="h1"
-          lineHeight="h1"
-        >
-          {item?.name}
-        </Heading>
-        <Box display="flex" my="m" flexWrap="wrap" justifyContent="center">
-          {series.map(({ node }) => (
-            <LargeImage
-              key={node?.id}
-              text={node?.title}
-              color="white"
-              src={node?.coverImage?.sources?.[0].uri}
-              height={{ sm: '350px' }}
-              size={{ _: 's', md: 'm' }}
-              maxWidth="400px"
-              mx="s"
-              mb="m"
-              action={() =>
-                router.push(
-                  `/watch/${router.query.series}/${getSlugFromURL(
-                    node?.sharing?.url
-                  )}`
-                )
-              }
-            />
-          ))}
-        </Box>
+      <Heading
+        mt="l"
+        textAlign="center"
+        fontWeight="800"
+        fontSize="h1"
+        lineHeight="h1"
+      >
+        {item?.name}
+      </Heading>
+      <Box display="flex" my="m" flexWrap="wrap" justifyContent="center">
+        {series.map(({ node }) => (
+          <LargeImage
+            key={node?.id}
+            text={node?.title}
+            color="white"
+            src={node?.coverImage?.sources?.[0].uri}
+            height={{ sm: '350px' }}
+            size={{ _: 's', md: 'm' }}
+            maxWidth="400px"
+            mx="s"
+            mb="m"
+            action={() =>
+              router.push(
+                `/watch/${router.query.series}/${getSlugFromURL(
+                  node?.sharing?.url
+                )}`
+              )
+            }
+          />
+        ))}
+      </Box>
       {totalSeriesCount > series?.length ? (
         <Button
           onClick={() => {


### PR DESCRIPTION
Adds back the background image blur for the main hero image on every page that had it before _except_ ones use the new `seriesBackgroundImage` field, e.g. /appetite.