### PR TITLE
Add News & Events to UniversalContentItem

### DIFF
--- a/components/HomeFeed/HomeFeed.js
+++ b/components/HomeFeed/HomeFeed.js
@@ -1,26 +1,25 @@
-import React, { useState } from 'react';
-import { ArrowRight, PlayCircle } from 'phosphor-react';
-import { useTheme } from 'styled-components';
-import { uniq } from 'lodash';
-
 import {
   ArticleLink,
+  ArticleLinks,
   Carousel,
+  ConnectTiles,
   FullWidthCTA,
   LargeImage,
   MainPhotoHeader,
   MarketingHeadline,
-  ConnectTiles,
   VideoPlayer,
-  ArticleLinks,
 } from 'components';
-import { Box, CardGrid, Heading, Section, Text } from 'ui-kit';
-import { useRouter } from 'next/router';
-import { getMediaSource, getSlugFromURL } from 'utils';
+import IDS from 'config/ids';
 import { useCurrentUser } from 'hooks';
 import usePersonaFeed from 'hooks/usePersonaFeed';
+import { uniq } from 'lodash';
+import { useRouter } from 'next/router';
+import { ArrowRight, PlayCircle } from 'phosphor-react';
+import React, { useState } from 'react';
+import { useTheme } from 'styled-components';
+import { Box, CardGrid, Heading, Section, Text } from 'ui-kit';
+import { getMediaSource, getSlugFromURL } from 'utils';
 import Styled from './HomeFeed.styles';
-import IDS from 'config/ids';
 
 function FullLengthSermon(props = {}) {
   const router = useRouter();

--- a/components/Siblings/Siblings.js
+++ b/components/Siblings/Siblings.js
@@ -1,9 +1,9 @@
 import LargeImage from 'components/LargeImage';
+import { format, parseISO } from 'date-fns';
 import { useRouter } from 'next/router';
 import { useTheme } from 'styled-components';
 import { Box } from 'ui-kit';
 import { getSlugFromURL } from 'utils';
-import { format, parseISO } from 'date-fns';
 
 export default function Siblings({ root }) {
   const theme = useTheme();
@@ -18,11 +18,14 @@ export default function Siblings({ root }) {
       flexWrap="wrap"
       justifyContent="center"
     >
-      {root.siblingContentItemsConnection.edges.map(({ node }) => console.log({ node }) || (
+      {root.siblingContentItemsConnection.edges.map(({ node }) => (
         <LargeImage
           key={node.id}
           text={node.title}
-          subtext={node.publishDate && format(parseISO(node.publishDate), 'MMMM do, yyyy')}
+          subtext={
+            node.publishDate &&
+            format(parseISO(node.publishDate), 'MMMM do, yyyy')
+          }
           color="white"
           src={node.coverImage.sources?.[0].uri}
           maxWidth="300px"


### PR DESCRIPTION
**DO NOT MERGE**

[Issue](https://3.basecamp.com/3926363/buckets/22579289/todos/4433063022)

Adds the News & Events callout to UniversalContentItem slug pages.

See /fall-offering-and-the-legacy-park-project for an example.
