### PR TITLE
Fix Load More Button

### DIFF
--- a/pages/watch/[series]/index.js
+++ b/pages/watch/[series]/index.js
@@ -1,12 +1,12 @@
-import { LargeImage, Layout } from 'components';
-import { initializeApollo } from 'lib/apolloClient';
-import { Box, Button, Heading, Section } from 'ui-kit';
-import IDS from 'config/ids';
-import { useRouter } from 'next/router';
-import { GET_MESSAGE_SERIES } from 'hooks/useMessageSeries';
-import { getChannelId, getMetaData, getSlugFromURL } from 'utils';
-import { useState } from 'react';
 import { useLazyQuery } from '@apollo/client';
+import { LargeImage, Layout } from 'components';
+import IDS from 'config/ids';
+import { GET_MESSAGE_SERIES } from 'hooks/useMessageSeries';
+import { initializeApollo } from 'lib/apolloClient';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
+import { Box, Button, Heading } from 'ui-kit';
+import { getChannelId, getMetaData, getSlugFromURL } from 'utils';
 
 export default function Series({ item, dropdownData } = {}) {
   const router = useRouter();


### PR DESCRIPTION
**DO NOT MERGE**

[Issue](https://3.basecamp.com/3926363/buckets/22579289/todos/4468583151)

Fixes the Load More button on watch series pages.

See /watch/71ec2079298288ea22cabf29ff907d73/standalone-messages for example

**Note** The sorting issue from the Basecamp link does not appear to still be an issue.