### PR TITLE
News events position

### DIFF
--- a/components/EventCallout/EventsCallout.js
+++ b/components/EventCallout/EventsCallout.js
@@ -1,30 +1,24 @@
-import { Box, Text } from 'ui-kit';
 import PropTypes from 'prop-types';
-import Styled from './EventsCallout.styles';
 import { useTheme } from 'styled-components';
+import { Box, Text } from 'ui-kit';
+import Styled from './EventsCallout.styles';
 
 function EventsCallout({ icon, title, children, ...props } = {}) {
   const theme = useTheme();
 
   return (
     <Box
-      height={{ _: 'auto', lg: theme.space.xl }}
       zIndex={1}
+      display="flex"
+      justifyContent="right"
       position="relative"
+      mb={{ _: 0, lg: 'm' }}
       {...props}
     >
-      <Styled
-        floater
-        width={{ _: 'auto', lg: theme.breakpoints.sm }}
-        position={{ _: 'initial', lg: 'absolute' }}
-      >
+      <Styled width={{ _: 'auto', lg: theme.breakpoints.sm }}>
         <Box display="flex" alignItems="center" mb="m">
           {icon}
-          <Text
-            color="neutrals.900"
-            opacity="60%"
-            fontWeight="600"
-          >
+          <Text color="neutrals.900" opacity="60%" fontWeight="600">
             {title}
           </Text>
         </Box>

--- a/components/EventCallout/EventsCallout.styles.js
+++ b/components/EventCallout/EventsCallout.styles.js
@@ -1,6 +1,5 @@
-import styled from 'styled-components';
 import { themeGet } from '@styled-system/theme-get';
-
+import styled from 'styled-components';
 import { system } from 'ui-kit';
 
 const EventsCallout = styled.div`
@@ -8,8 +7,6 @@ const EventsCallout = styled.div`
   border-radius: 0;
   box-shadow: 0px 20px 48px rgba(0, 0, 0, 0.04);
   padding: ${themeGet('space.m')} ${themeGet('space.l')};
-  right: 0;
-  ${props => (props.floater ? 'bottom: 0' : 'top: 0')};
 
   @media screen and (min-width: ${themeGet('breakpoints.md')}) {
     padding: ${themeGet('space.l')} ${themeGet('space.xxl')};
@@ -19,8 +16,6 @@ const EventsCallout = styled.div`
     border-radius: ${themeGet('radii.image')};
     margin-top: 0px;
     padding: ${themeGet('space.m')};
-    right: 50%;
-    transform: translate(100%, 0);
   }
 
   ${system}

--- a/components/MainPhotoHeader/MainPhotoHeader.js
+++ b/components/MainPhotoHeader/MainPhotoHeader.js
@@ -130,7 +130,7 @@ function MainPhotoHeader({
               />
             }
           >
-            {[...events, ...events].map(link => (
+            {events.map(link => (
               <EventCallout
                 key={link.id}
                 title={link.title}

--- a/components/MainPhotoHeader/MainPhotoHeader.js
+++ b/components/MainPhotoHeader/MainPhotoHeader.js
@@ -1,7 +1,11 @@
-import React from 'react';
+import { EventCallout, EventsCallout } from 'components';
+import { useRouter } from 'next/router';
+import { Info } from 'phosphor-react';
 import PropTypes from 'prop-types';
-
-import { Heading } from 'ui-kit';
+import React from 'react';
+import { useTheme } from 'styled-components';
+import { Heading, Section } from 'ui-kit';
+import { getSlugFromURL } from 'utils';
 import Styled from './MainPhotoHeader.styles';
 
 function MainPhotoHeader({
@@ -20,8 +24,11 @@ function MainPhotoHeader({
   justifyText,
   bgBlurred,
   imageProps = {},
+  events,
   ...props
 } = {}) {
+  const theme = useTheme();
+  const router = useRouter();
   const _backgroundSrc = backgroundSrc || src;
   return (
     <Styled.Container {...props}>
@@ -105,6 +112,38 @@ function MainPhotoHeader({
         )}
       </Styled.ImageContainer>
       {content}
+      {events?.length ? (
+        <Section contentProps={{ p: '0 !important' }}>
+          <EventsCallout
+            mx={{ _: 0, lg: 'xl' }}
+            mb={{ _: 'l', lg: `-${theme.space.xl}` }}
+            mt={{ lg: `-${theme.space.xxl}` }}
+            title="News & Events"
+            icon={
+              <Info
+                size={24}
+                style={{
+                  color: theme.colors.neutrals[900],
+                  opacity: '60%',
+                  marginRight: theme.space.xxs,
+                }}
+              />
+            }
+          >
+            {[...events, ...events].map(link => (
+              <EventCallout
+                key={link.id}
+                title={link.title}
+                description={link.subtitle}
+                imageSrc={link.coverImage?.sources?.[0]?.uri}
+                onClick={() =>
+                  router.push(`/${getSlugFromURL(link?.sharing?.url)}`)
+                }
+              />
+            ))}
+          </EventsCallout>
+        </Section>
+      ) : null}
     </Styled.Container>
   );
 }

--- a/components/MainPhotoHeader/MainPhotoHeader.styles.js
+++ b/components/MainPhotoHeader/MainPhotoHeader.styles.js
@@ -1,6 +1,5 @@
 import { themeGet } from '@styled-system/theme-get';
 import styled, { css } from 'styled-components';
-
 import { Box, Image, system } from 'ui-kit';
 
 const Styled = {};
@@ -9,7 +8,7 @@ Styled.Container = styled(Box)`
   position: relative;
   text-align: center;
   width: 100%;
-  background-color: ${themeGet('colors.neutrals.900')};
+  background-color: ${themeGet('colors.bg_alt')};
 
   ${system}
 `;

--- a/components/SinglePages/UniversalContentItem.js
+++ b/components/SinglePages/UniversalContentItem.js
@@ -3,8 +3,6 @@ import {
   ArticleLink,
   ArticleLinks,
   CampusFilter,
-  EventCallout,
-  EventsCallout,
   Layout,
   MainPhotoHeader,
 } from 'components';
@@ -13,8 +11,6 @@ import MetadataCallout, { getMetadataObj } from 'components/MetadataCallout';
 import IDS from 'config/ids';
 import { format, isSameMonth, isSameYear, parseISO } from 'date-fns';
 import { useRouter } from 'next/router';
-import { Info } from 'phosphor-react';
-import { useTheme } from 'styled-components';
 import { Box, Button, CardGrid, Heading, Longform, Section } from 'ui-kit';
 import { getIdSuffix, getMetaData, getSlugFromURL } from 'utils';
 
@@ -25,7 +21,6 @@ export default function Page({
   dropdownData,
 } = {}) {
   const router = useRouter();
-  const theme = useTheme();
 
   // add rock authenticated links
   const { data: authData } = useQuery(
@@ -121,39 +116,8 @@ export default function Page({
         width="auto"
         overlay=""
         mb={{ _: 'l', md: 'xxl' }}
+        events={links?.length && showEventsCallout ? links : null}
       />
-      {links?.length && showEventsCallout ? (
-        <Section contentProps={{ p: '0 !important' }}>
-          <EventsCallout
-            mx={{ _: 0, lg: 'xl' }}
-            mb={{ _: 'l', md: 'xxl' }}
-            my={{ lg: `-${theme.space.xxl}` }}
-            title="News & Events"
-            icon={
-              <Info
-                size={24}
-                style={{
-                  color: theme.colors.neutrals[900],
-                  opacity: '60%',
-                  marginRight: theme.space.xxs,
-                }}
-              />
-            }
-          >
-            {links.map(link => (
-              <EventCallout
-                key={link.id}
-                title={link.title}
-                description={link.subtitle}
-                imageSrc={link.coverImage?.sources?.[0]?.uri}
-                onClick={() =>
-                  router.push(`/${getSlugFromURL(link?.sharing?.url)}`)
-                }
-              />
-            ))}
-          </EventsCallout>
-        </Section>
-      ) : null}
       <Section mb={{ _: 'l' }}>
         <Box>
           {data.subtitle && (

--- a/pages/about/[page].js
+++ b/pages/about/[page].js
@@ -1,7 +1,5 @@
 import {
   CampusFilter,
-  EventCallout,
-  EventsCallout,
   Layout,
   MainPhotoHeader,
   MarketingHeadline,
@@ -13,9 +11,7 @@ import { GET_MINISTRY_CONTENT } from 'hooks/useMinistryContent';
 import { GET_UNIVERSAL_CONTENT_ITEM_BY_SLUG } from 'hooks/useUniversalContentItemBySlug';
 import { initializeApollo } from 'lib/apolloClient';
 import { useRouter } from 'next/router';
-import { Info } from 'phosphor-react';
 import { useEffect } from 'react';
-import { useTheme } from 'styled-components';
 import { CardGrid, Longform, Section } from 'ui-kit';
 import { getChannelId, getIdSuffix, getMetaData, getSlugFromURL } from 'utils';
 
@@ -26,7 +22,6 @@ export default function Page({
   relatedContent,
 }) {
   const router = useRouter();
-  const theme = useTheme();
 
   // next.config.js isn't working for redirects when clicking on the link to redirect from
   useEffect(() => {
@@ -61,39 +56,8 @@ export default function Page({
         summary={data.summary}
         showTitleOverImage={data.showTitleOverImage}
         mb={{ _: 'l', md: 'xxl' }}
+        events={links?.length ? links : null}
       />
-      {links?.length ? (
-        <Section contentProps={{ p: '0 !important' }}>
-          <EventsCallout
-            mx={{ _: 0, lg: 'xl' }}
-            mb={{ _: 'l', md: 'xxl' }}
-            my={{ lg: `-${theme.space.xxl}` }}
-            title="News & Events"
-            icon={
-              <Info
-                size={24}
-                style={{
-                  color: theme.colors.neutrals[900],
-                  opacity: '60%',
-                  marginRight: theme.space.xxs,
-                }}
-              />
-            }
-          >
-            {links.map(link => (
-              <EventCallout
-                key={link.id}
-                title={link.title}
-                description={link.subtitle}
-                imageSrc={link.coverImage?.sources?.[0]?.uri}
-                onClick={() =>
-                  router.push(`/${getSlugFromURL(link?.sharing?.url)}`)
-                }
-              />
-            ))}
-          </EventsCallout>
-        </Section>
-      ) : null}
       {data.htmlContent && (
         <Section>
           <Longform

--- a/pages/connect/[page].js
+++ b/pages/connect/[page].js
@@ -1,19 +1,21 @@
-import { useRouter } from 'next/router';
-
-import { GET_CONTENT_CHANNEL } from 'hooks/useContentChannel';
 import {
   ArticleLink,
   ArticleLinks,
   CampusFilter,
-  EventCallout,
-  EventsCallout,
   Layout,
   MainPhotoHeader,
   MarketingHeadline,
-  MeetTheStaff,
   PageSplit,
   Quote,
 } from 'components';
+import IDS from 'config/ids';
+import { GET_CAMPUSES } from 'hooks/useCampuses';
+import { GET_CONTENT_CHANNEL } from 'hooks/useContentChannel';
+// import { GET_STAFF } from 'hooks/useStaff';
+import { GET_MINISTRY_CONTENT } from 'hooks/useMinistryContent';
+import { GET_UNIVERSAL_CONTENT_ITEM_BY_SLUG } from 'hooks/useUniversalContentItemBySlug';
+import { initializeApollo } from 'lib/apolloClient';
+import { useRouter } from 'next/router';
 import { Button, CardGrid, Longform, Section } from 'ui-kit';
 import {
   getChildrenByType,
@@ -21,14 +23,6 @@ import {
   getMetaData,
   getSlugFromURL,
 } from 'utils';
-import IDS from 'config/ids';
-import { initializeApollo } from 'lib/apolloClient';
-import { Info } from 'phosphor-react';
-import { useTheme } from 'styled-components';
-// import { GET_STAFF } from 'hooks/useStaff';
-import { GET_MINISTRY_CONTENT } from 'hooks/useMinistryContent';
-import { GET_CAMPUSES } from 'hooks/useCampuses';
-import { GET_UNIVERSAL_CONTENT_ITEM_BY_SLUG } from 'hooks/useUniversalContentItemBySlug';
 
 export default function Page({
   data = {},
@@ -38,7 +32,6 @@ export default function Page({
   dropdownData,
 }) {
   const router = useRouter();
-  const theme = useTheme();
 
   const { loading, error, getContentBySlug: node } = data;
 
@@ -56,8 +49,8 @@ export default function Page({
   );
 
   const story = stories.length ? stories[0] : null;
-  const ctaLinks = node.ctaLinks.filter((cta) => cta.image?.sources?.[0]?.uri);
-  const extraCTA = node.ctaLinks.filter((cta) => !cta.image?.sources?.[0]?.uri);
+  const ctaLinks = node.ctaLinks.filter(cta => cta.image?.sources?.[0]?.uri);
+  const extraCTA = node.ctaLinks.filter(cta => !cta.image?.sources?.[0]?.uri);
 
   let links = relatedContent?.getMinistryContent?.length
     ? relatedContent.getMinistryContent.slice(0, 4)
@@ -87,39 +80,8 @@ export default function Page({
               : 0,
           lg: 'xxl',
         }}
+        events={links?.length ? links : null}
       />
-      {links?.length ? (
-        <Section contentProps={{ p: '0 !important' }}>
-          <EventsCallout
-            mx={{ _: 0, lg: 'xl' }}
-            mb={{ _: 'l', md: 'xxl' }}
-            my={{ lg: `-${theme.space.xxl}` }}
-            title="News & Events"
-            icon={
-              <Info
-                size={24}
-                style={{
-                  color: theme.colors.neutrals[900],
-                  opacity: '60%',
-                  marginRight: theme.space.xxs,
-                }}
-              />
-            }
-          >
-            {links.map(link => (
-              <EventCallout
-                key={link.id}
-                title={link.title}
-                description={link.subtitle}
-                imageSrc={link.coverImage?.sources?.[0]?.uri}
-                onClick={() =>
-                  router.push(`/${getSlugFromURL(link?.sharing?.url)}`)
-                }
-              />
-            ))}
-          </EventsCallout>
-        </Section>
-      ) : null}
       {node.htmlContent && (
         <Section>
           <Longform

--- a/pages/next-steps/[page].js
+++ b/pages/next-steps/[page].js
@@ -1,25 +1,20 @@
-import { useRouter } from 'next/router';
-
-import { GET_CONTENT_CHANNEL } from 'hooks/useContentChannel';
 import {
   ArticleLink,
   ArticleLinks,
   CampusFilter,
-  EventCallout,
-  EventsCallout,
   Layout,
   MainPhotoHeader,
   MarketingHeadline,
 } from 'components';
 import IDS from 'config/ids';
+import { GET_CAMPUSES } from 'hooks/useCampuses';
+import { GET_CONTENT_CHANNEL } from 'hooks/useContentChannel';
+import { GET_MINISTRY_CONTENT } from 'hooks/useMinistryContent';
+import { GET_UNIVERSAL_CONTENT_ITEM_BY_SLUG } from 'hooks/useUniversalContentItemBySlug';
+import { initializeApollo } from 'lib/apolloClient';
+import { useRouter } from 'next/router';
 import { CardGrid, Longform, Section } from 'ui-kit';
 import { getIdSuffix, getMetaData, getSlugFromURL } from 'utils';
-import { initializeApollo } from 'lib/apolloClient';
-import { GET_CAMPUSES } from 'hooks/useCampuses';
-import { GET_UNIVERSAL_CONTENT_ITEM_BY_SLUG } from 'hooks/useUniversalContentItemBySlug';
-import { useTheme } from 'styled-components';
-import { Info } from 'phosphor-react';
-import { GET_MINISTRY_CONTENT } from 'hooks/useMinistryContent';
 
 export default function Page({
   data = {},
@@ -27,7 +22,6 @@ export default function Page({
   dropdownData,
   relatedContent,
 }) {
-  const theme = useTheme();
   const router = useRouter();
 
   const { loading, error, getContentBySlug: node = {} } = data;
@@ -60,46 +54,16 @@ export default function Page({
         showTitleOverImage={node.showTitleOverImage}
         summary={node.summary}
         mb={{
-          _:
-            links?.length ? 0 : ((node.title || node.subtitle || node.summary) &&
-              node.showTitleOverImage)
-              ? 'xl'
-              : 0,
+          _: links?.length
+            ? 0
+            : (node.title || node.subtitle || node.summary) &&
+              node.showTitleOverImage
+            ? 'xl'
+            : 0,
           lg: 'xxl',
         }}
+        events={links?.length ? links : null}
       />
-      {links?.length ? (
-        <Section contentProps={{ p: '0 !important' }}>
-          <EventsCallout
-            mx={{ _: 0, lg: 'xl' }}
-            mb={{ _: 'l', md: 'xxl' }}
-            my={{ lg: `-${theme.space.xxl}` }}
-            title="News & Events"
-            icon={
-              <Info
-                size={24}
-                style={{
-                  color: theme.colors.neutrals[900],
-                  opacity: '60%',
-                  marginRight: theme.space.xxs,
-                }}
-              />
-            }
-          >
-            {links.map(link => (
-              <EventCallout
-                key={link.id}
-                title={link.title}
-                description={link.subtitle}
-                imageSrc={link.coverImage?.sources?.[0]?.uri}
-                onClick={() =>
-                  router.push(`/${getSlugFromURL(link?.sharing?.url)}`)
-                }
-              />
-            ))}
-          </EventsCallout>
-        </Section>
-      ) : null}
       {node.htmlContent && (
         <Section>
           <Longform


### PR DESCRIPTION
### About
Updates News & Events callout to push content down instead of expanding upwards and covering main photo header

### Test Instructions
Go to /connect/students

### Screenshots
**Normal case**
<img width="1453" alt="Screen Shot 2022-03-04 at 5 13 37 PM" src="https://user-images.githubusercontent.com/3879073/156849054-6f46ea96-6039-429f-a569-93947157c5f6.png">

**Extreme case**
<img width="1451" alt="Screen Shot 2022-03-04 at 5 12 03 PM" src="https://user-images.githubusercontent.com/3879073/156848889-47701f72-0e1d-4a10-8aa6-40a428f428e5.png">

### Closes Tickets
https://3.basecamp.com/3926363/buckets/22579289/todos/4697085455


