### PR TITLE
Fix bg of main photo header on mobile or w/ events

### DIFF
--- a/components/EventCallout/EventsCallout.js
+++ b/components/EventCallout/EventsCallout.js
@@ -15,7 +15,7 @@ function EventsCallout({ icon, title, children, ...props } = {}) {
       mb={{ _: 0, lg: 'm' }}
       {...props}
     >
-      <Styled width={{ _: 'auto', lg: theme.breakpoints.sm }}>
+      <Styled width={{ _: '100%', lg: theme.breakpoints.sm }}>
         <Box display="flex" alignItems="center" mb="m">
           {icon}
           <Text color="neutrals.900" opacity="60%" fontWeight="600">

--- a/components/MainPhotoHeader/MainPhotoHeader.styles.js
+++ b/components/MainPhotoHeader/MainPhotoHeader.styles.js
@@ -8,7 +8,6 @@ Styled.Container = styled(Box)`
   position: relative;
   text-align: center;
   width: 100%;
-  background-color: ${themeGet('colors.fg')};
 
   ${system}
 `;
@@ -131,28 +130,28 @@ Styled.ImageOverlay = styled(Box)`
 `;
 
 Styled.TextContainer = styled(Box)`
+  background-color: ${themeGet('colors.fg')};
   flex-direction: column;
-  margin-bottom: ${themeGet('space.l')};
+  padding-bottom: ${themeGet('space.l')};
   text-shadow: 2px 2px 8px rgba(0, 0, 0, 0.1);
   word-break: break-word;
   z-index: 1;
 
   @media screen and (max-width: ${themeGet('breakpoints.md')}) {
     padding: ${themeGet('space.l')};
-    padding-bottom: 0;
   }
 
   @media screen and (min-width: ${themeGet('breakpoints.md')}) {
     bottom: unset;
     height: auto;
     left: 0;
-    margin: ${themeGet('space.l')} ${themeGet('space.xxl')};
+    padding: ${themeGet('space.l')} ${themeGet('space.xxl')};
     max-width: unset;
     position: relative;
   }
 
   @media screen and (min-width: ${themeGet('breakpoints.lg')}) {
-    margin: 0;
+    background-color: inherit;
     padding: 0 ${themeGet('space.xxl')} ${themeGet('space.l')};
     height: 100%;
     max-width: ${themeGet('space.content')};


### PR DESCRIPTION
@redreceipt Looks like there was a slight regression with a couple of the previous PRs. This PR is a fix for those.

**Production**
<img width="395" alt="Screen Shot 2022-03-24 at 11 06 35 AM" src="https://user-images.githubusercontent.com/3879073/159947093-f676e65e-c8b9-43a4-85a2-7c2f40e2e834.png">
<img width="1276" alt="Screen Shot 2022-03-24 at 11 07 32 AM" src="https://user-images.githubusercontent.com/3879073/159947288-5c654c07-b634-4798-b321-190113a3b416.png">

**Fixed**
<img width="386" alt="Screen Shot 2022-03-24 at 11 05 50 AM" src="https://user-images.githubusercontent.com/3879073/159946915-e0760092-6bcc-4d1c-b232-c1426184e937.png">

<img width="1128" alt="Screen Shot 2022-03-24 at 11 06 10 AM" src="https://user-images.githubusercontent.com/3879073/159947001-7892faa5-747f-4a79-9af3-1e43bc76e274.png">

**MainPhotoHeader text background still works**
<img width="502" alt="Screen Shot 2022-03-24 at 11 04 55 AM" src="https://user-images.githubusercontent.com/3879073/159946742-100fb710-3e9d-437f-b10b-22cd66908f77.png">

 