### PR TITLE
Slice news & events items after filtering

### DIFF
--- a/components/SinglePages/UniversalContentItem.js
+++ b/components/SinglePages/UniversalContentItem.js
@@ -98,16 +98,18 @@ export default function Page({
 
   const childContent = data.childContentItemsConnection?.edges;
   let links = relatedContent?.getMinistryContent?.length
-    ? relatedContent.getMinistryContent.slice(0, 4)
+    ? relatedContent.getMinistryContent
     : [];
 
-  links = links.filter(
-    link =>
-      getSlugFromURL(link?.sharing?.url) !== router.query.page &&
-      (getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.EVENTS ||
-        getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.ARTICLES) &&
-      link.id !== data.id
-  );
+  links = links
+    .filter(
+      link =>
+        getSlugFromURL(link?.sharing?.url) !== router.query.page &&
+        (getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.EVENTS ||
+          getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.ARTICLES) &&
+        link.id !== data.id
+    )
+    .slice(0, 4);
 
   return (
     <Layout meta={getMetaData(data)} bg="bg_alt" dropdownData={dropdownData}>

--- a/pages/about/[page].js
+++ b/pages/about/[page].js
@@ -38,15 +38,17 @@ export default function Page({
   const ctaLinks = data.ctaLinks;
 
   let links = relatedContent?.getMinistryContent?.length
-    ? relatedContent.getMinistryContent.slice(0, 4)
+    ? relatedContent.getMinistryContent
     : [];
 
-  links = links.filter(
-    link =>
-      getSlugFromURL(link?.sharing?.url) !== router.query.page &&
-      (getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.EVENTS ||
-        getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.ARTICLES)
-  );
+  links = links
+    .filter(
+      link =>
+        getSlugFromURL(link?.sharing?.url) !== router.query.page &&
+        (getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.EVENTS ||
+          getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.ARTICLES)
+    )
+    .slice(0, 4);
   return (
     <Layout meta={getMetaData(data)} bg="bg_alt" dropdownData={dropdownData}>
       <MainPhotoHeader

--- a/pages/connect/[page].js
+++ b/pages/connect/[page].js
@@ -53,15 +53,17 @@ export default function Page({
   const extraCTA = node.ctaLinks.filter(cta => !cta.image?.sources?.[0]?.uri);
 
   let links = relatedContent?.getMinistryContent?.length
-    ? relatedContent.getMinistryContent.slice(0, 4)
+    ? relatedContent.getMinistryContent
     : [];
 
-  links = links.filter(
-    link =>
-      getSlugFromURL(link?.sharing?.url) !== router.query.page &&
-      (getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.EVENTS ||
-        getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.ARTICLES)
-  );
+  links = links
+    .filter(
+      link =>
+        getSlugFromURL(link?.sharing?.url) !== router.query.page &&
+        (getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.EVENTS ||
+          getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.ARTICLES)
+    )
+    .slice(0, 4);
 
   return (
     <Layout meta={getMetaData(node)} bg="bg_alt" dropdownData={dropdownData}>

--- a/pages/next-steps/[page].js
+++ b/pages/next-steps/[page].js
@@ -35,15 +35,17 @@ export default function Page({
   const childContent = node.childContentItemsConnection?.edges;
 
   let links = relatedContent?.getMinistryContent?.length
-    ? relatedContent.getMinistryContent.slice(0, 4)
+    ? relatedContent.getMinistryContent
     : [];
 
-  links = links.filter(
-    link =>
-      getSlugFromURL(link?.sharing?.url) !== router.query.page &&
-      (getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.EVENTS ||
-        getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.ARTICLES)
-  );
+  links = links
+    .filter(
+      link =>
+        getSlugFromURL(link?.sharing?.url) !== router.query.page &&
+        (getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.EVENTS ||
+          getIdSuffix(link.parentChannel?.id) === IDS.CHANNELS.ARTICLES)
+    )
+    .slice(0, 4);
 
   return (
     <Layout meta={getMetaData(node)} bg="bg_alt" dropdownData={dropdownData}>


### PR DESCRIPTION
Event links array was getting truncated _before_ filtering, which would cause some items to not show if they were later in the array despite being valid in the filter.