### PR TITLE
turns SSR off for livestreams

### DIFF
--- a/hooks/useLiveStreams.js
+++ b/hooks/useLiveStreams.js
@@ -40,6 +40,7 @@ function useLiveStreams(options = {}) {
     ...options,
     cachePolicy: 'network-only',
     errorPolicy: 'ignore',
+    ssr: false,
   });
   const firstStream = query?.data?.liveStreams?.[0];
   let prettyCountdown;


### PR DESCRIPTION
This pull request includes a small change to the `hooks/useLiveStreams.js` file. The change adds a new option to the `useLiveStreams` function to disable server-side rendering (SSR).

* [`hooks/useLiveStreams.js`](diffhunk://#diff-e259a0b8c11abe7d307312c5c2fc88f03aa3d2633aa7ca0772338814eb4c6cd8R43): Added the `ssr: false` option to the `useLiveStreams` function to disable server-side rendering.